### PR TITLE
Phase 2.5: UX改善実装 - メンション対応・プログレス表示・スレッド管理強化

### DIFF
--- a/lib/__tests__/slack-ai-agent-stack.test.ts
+++ b/lib/__tests__/slack-ai-agent-stack.test.ts
@@ -96,7 +96,7 @@ describe('SlackAiAgentDemoStack', () => {
         Statement: Match.arrayWith([
           {
             Effect: 'Allow',
-            Action: ['s3:ListBucket', 's3:GetObjectAttributes'],
+            Action: ['s3:ListBucket', 's3:GetObjectAttributes', 's3:GetObject'],
             Resource: ['arn:aws:s3:::*', 'arn:aws:s3:::*/*'],
           },
         ]),

--- a/lib/slack-ai-agent-stack.ts
+++ b/lib/slack-ai-agent-stack.ts
@@ -24,6 +24,7 @@ export class SlackAiAgentDemoStack extends cdk.Stack {
       actions: [
         's3:ListBucket',
         's3:GetObjectAttributes',
+        's3:GetObject', // Added for presigned URL generation
       ],
       resources: [
         'arn:aws:s3:::*', // Dynamic bucket name from SSM
@@ -47,8 +48,8 @@ export class SlackAiAgentDemoStack extends cdk.Stack {
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
       bundling: {
-        externalModules: ['aws-sdk'],
-        forceDockerBundling: false,
+        externalModules: [],
+        forceDockerBundling: false,  // ローカルバンドリング強制
       },
       environment: {
         NODE_ENV: 'production',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/client-ssm": "^3.828.0",
         "@aws-sdk/s3-request-presigner": "^3.828.0",
         "@slack/bolt": "^3.17.1",
+        "@slack/web-api": "^7.9.2",
         "aws-cdk-lib": "^2.108.1",
         "aws-lambda": "^1.0.7",
         "constructs": "^10.3.0",
@@ -2292,6 +2293,73 @@
         "npm": ">=6.14.18"
       }
     },
+    "node_modules/@slack/bolt/node_modules/@slack/web-api": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.13.0.tgz",
+      "integrity": "sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.11.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^1.7.4",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/bolt/node_modules/@slack/web-api/node_modules/@slack/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=12.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/bolt/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@slack/bolt/node_modules/form-data": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
+      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@slack/bolt/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@slack/logger": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
@@ -2336,6 +2404,60 @@
         "npm": ">= 6.12.0"
       }
     },
+    "node_modules/@slack/oauth/node_modules/@slack/web-api": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.13.0.tgz",
+      "integrity": "sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.11.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^1.7.4",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/oauth/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@slack/oauth/node_modules/form-data": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
+      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@slack/oauth/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@slack/socket-mode": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-1.3.6.tgz",
@@ -2368,17 +2490,7 @@
         "npm": ">= 6.12.0"
       }
     },
-    "node_modules/@slack/types": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.14.0.tgz",
-      "integrity": "sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0",
-        "npm": ">= 6.12.0"
-      }
-    },
-    "node_modules/@slack/web-api": {
+    "node_modules/@slack/socket-mode/node_modules/@slack/web-api": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.13.0.tgz",
       "integrity": "sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g==",
@@ -2401,24 +2513,70 @@
         "npm": ">= 6.12.0"
       }
     },
-    "node_modules/@slack/web-api/node_modules/@slack/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+    "node_modules/@slack/socket-mode/node_modules/@slack/web-api/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@slack/socket-mode/node_modules/form-data": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
+      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": ">=12.0.0"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
       },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@slack/socket-mode/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.14.0.tgz",
+      "integrity": "sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12.13.0",
         "npm": ">= 6.12.0"
       }
     },
-    "node_modules/@slack/web-api/node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "license": "MIT"
+    "node_modules/@slack/web-api": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.9.2.tgz",
+      "integrity": "sha512-3HoDwV6+ZSTfV+DsbnUd82GlZY0a+DPXuHQHpxWTqgxjM3JWZyGiwR+ov3d2M16pWiMzA+l58UJ5lm1znGq0yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/types": "^2.9.0",
+        "@types/node": ">=18.0.0",
+        "@types/retry": "0.12.0",
+        "axios": "^1.8.3",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.0.4",
@@ -4347,22 +4505,6 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -5750,19 +5892,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/execa/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -6112,19 +6241,19 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
-      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -7021,12 +7150,15 @@
       }
     },
     "node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@aws-sdk/client-ssm": "^3.828.0",
     "@aws-sdk/s3-request-presigner": "^3.828.0",
     "@slack/bolt": "^3.17.1",
+    "@slack/web-api": "^7.9.2",
     "aws-cdk-lib": "^2.108.1",
     "aws-lambda": "^1.0.7",
     "constructs": "^10.3.0",

--- a/src/lambda/__tests__/slack-handler.test.ts
+++ b/src/lambda/__tests__/slack-handler.test.ts
@@ -15,7 +15,7 @@ jest.mock('@aws-sdk/client-ssm', () => ({
 
 jest.mock('@slack/bolt', () => ({
   App: jest.fn().mockImplementation(() => ({
-    message: jest.fn(),
+    event: jest.fn(),
     start: jest.fn(),
     receiver: {
       toHandler: jest.fn().mockReturnValue(async (event: any, context: any) => ({
@@ -47,6 +47,14 @@ jest.mock('@slack/bolt', () => ({
         'Content-Type': 'application/json',
       },
     })),
+  })),
+}));
+
+jest.mock('@slack/web-api', () => ({
+  WebClient: jest.fn().mockImplementation(() => ({
+    chat: {
+      update: jest.fn().mockResolvedValue({ ok: true }),
+    },
   })),
 }));
 


### PR DESCRIPTION
## 概要
Phase 2.5としてSlack BotのUX改善を実装しました。企業環境での実用性を向上させ、より自然なBot体験を提供します。

## 実装内容

### 1. メンション時のみ反応
- `app.message()` → `app.event('app_mention')` に変更
- チャンネル全体への無差別反応を回避
- `@Slack AI Agent` メンション時のみ動作

### 2. スレッド管理の強化
- 必ずスレッド返信でチャンネル占有を完全回避
- `threadTs = event.thread_ts || event.ts` でスレッド継続
- 元ポストがスレッド内でも適切に継続

### 3. プログレス表示機能
- AWS操作時に即座に「📡 処理中...」表示
- `client.chat.update()` でリアルタイム更新
- 成功/エラー時も同じメッセージを更新

## 技術的改善

### 依存関係追加
- `@slack/web-api` WebClient追加
- chat.updateによるメッセージ更新対応

### AWS権限追加
- S3の `s3:GetObject` 権限追加
- presigned URL生成の安定性向上

### CDK設定最適化
- バンドリング設定を協調リポジトリ要件に適合
- `forceDockerBundling: false` でローカルバンドリング強制

## 使用方法

```
@Slack AI Agent hello
→ スレッドで Hello, World\! 応答

@Slack AI Agent list-s3  
→ 即座に「📡 S3情報を取得中...」
→ 同じメッセージが結果で更新される

@Slack AI Agent s3-url demo-text.txt
→ 即座に「📡 ダウンロードURL生成中...」  
→ 同じメッセージがリンクで更新される
```

## 期待される効果

1. **チャンネル占有の完全回避**: メンション時のみ + 必ずスレッド返信
2. **レスポンシブな体験**: 即座のフィードバック + リアルタイム更新  
3. **企業環境での実用性**: 自然な会話フロー

## テスト結果
- ✅ 全11テスト成功
- ✅ CDKスタック検証済み
- ✅ 型安全性確保済み

## 次のステップ
管理マシンでのデプロイ後、Slack App設定で `app_mention` イベントの有効化が必要です。

🤖 Generated with [Claude Code](https://claude.ai/code)